### PR TITLE
feat(precompiles/erc20): implement burn & burnFrom methods in erc20 precompile

### DIFF
--- a/precompiles/erc20/IERC20Burnable.sol
+++ b/precompiles/erc20/IERC20Burnable.sol
@@ -15,4 +15,25 @@ interface IERC20Burnable is IERC20 {
      * See {ERC20-_burn}.
      */
     function burn(uint256 amount) external;
+
+    /**
+     * @dev Destroys `amount` tokens from `from`.
+     *
+     * See {ERC20-_burn} and {ERC20-allowance}.
+     *
+     */
+    function burn(address from, uint256 amount) external;
+
+    /**
+     * @dev Destroys a `value` amount of tokens from `account`, deducting from
+     * the caller's allowance.
+     *
+     * See {ERC20-_burn} and {ERC20-allowance}.
+     *
+     * Requirements:
+     *
+     * - the caller must have allowance for ``accounts``'s tokens of at least
+     * `value`.
+     */
+    function burnFrom(address account, uint256 value) external;
 }

--- a/precompiles/erc20/abi.json
+++ b/precompiles/erc20/abi.json
@@ -4,6 +4,28 @@
   "sourceName": "solidity/precompiles/erc20/IERC20MetadataAllowance.sol",
   "abi": [
 		{
+			"inputs": [
+				{
+					"internalType": "address",
+					"name": "owner",
+					"type": "address"
+				}
+			],
+			"name": "OwnableInvalidOwner",
+			"type": "error"
+		},
+		{
+			"inputs": [
+				{
+					"internalType": "address",
+					"name": "account",
+					"type": "address"
+				}
+			],
+			"name": "OwnableUnauthorizedAccount",
+			"type": "error"
+		},
+		{
 			"anonymous": false,
 			"inputs": [
 				{
@@ -26,6 +48,25 @@
 				}
 			],
 			"name": "Approval",
+			"type": "event"
+		},
+		{
+			"anonymous": false,
+			"inputs": [
+				{
+					"indexed": true,
+					"internalType": "address",
+					"name": "previousOwner",
+					"type": "address"
+				},
+				{
+					"indexed": true,
+					"internalType": "address",
+					"name": "newOwner",
+					"type": "address"
+				}
+			],
+			"name": "OwnershipTransferred",
 			"type": "event"
 		},
 		{
@@ -269,6 +310,19 @@
 		},
 		{
 			"inputs": [],
+			"name": "owner",
+			"outputs": [
+				{
+					"internalType": "address",
+					"name": "",
+					"type": "address"
+				}
+			],
+			"stateMutability": "view",
+			"type": "function"
+		},
+		{
+			"inputs": [],
 			"name": "symbol",
 			"outputs": [
 				{
@@ -343,6 +397,19 @@
 					"type": "bool"
 				}
 			],
+			"stateMutability": "nonpayable",
+			"type": "function"
+		},
+		{
+			"inputs": [
+				{
+					"internalType": "address",
+					"name": "newOwner",
+					"type": "address"
+				}
+			],
+			"name": "transferOwnership",
+			"outputs": [],
 			"stateMutability": "nonpayable",
 			"type": "function"
 		}

--- a/precompiles/erc20/abi.json
+++ b/precompiles/erc20/abi.json
@@ -2,29 +2,7 @@
   "_format": "hh-sol-artifact-1",
   "contractName": "IERC20MetadataAllowance",
   "sourceName": "solidity/precompiles/erc20/IERC20MetadataAllowance.sol",
-  "abi":[
-		{
-			"inputs": [
-				{
-					"internalType": "address",
-					"name": "owner",
-					"type": "address"
-				}
-			],
-			"name": "OwnableInvalidOwner",
-			"type": "error"
-		},
-		{
-			"inputs": [
-				{
-					"internalType": "address",
-					"name": "account",
-					"type": "address"
-				}
-			],
-			"name": "OwnableUnauthorizedAccount",
-			"type": "error"
-		},
+  "abi": [
 		{
 			"anonymous": false,
 			"inputs": [
@@ -56,51 +34,6 @@
 				{
 					"indexed": true,
 					"internalType": "address",
-					"name": "account",
-					"type": "address"
-				}
-			],
-			"name": "MinterAdded",
-			"type": "event"
-		},
-		{
-			"anonymous": false,
-			"inputs": [
-				{
-					"indexed": true,
-					"internalType": "address",
-					"name": "account",
-					"type": "address"
-				}
-			],
-			"name": "MinterRemoved",
-			"type": "event"
-		},
-		{
-			"anonymous": false,
-			"inputs": [
-				{
-					"indexed": true,
-					"internalType": "address",
-					"name": "previousOwner",
-					"type": "address"
-				},
-				{
-					"indexed": true,
-					"internalType": "address",
-					"name": "newOwner",
-					"type": "address"
-				}
-			],
-			"name": "OwnershipTransferred",
-			"type": "event"
-		},
-		{
-			"anonymous": false,
-			"inputs": [
-				{
-					"indexed": true,
-					"internalType": "address",
 					"name": "from",
 					"type": "address"
 				},
@@ -119,19 +52,6 @@
 			],
 			"name": "Transfer",
 			"type": "event"
-		},
-		{
-			"inputs": [
-				{
-					"internalType": "address",
-					"name": "account",
-					"type": "address"
-				}
-			],
-			"name": "addMinter",
-			"outputs": [],
-			"stateMutability": "nonpayable",
-			"type": "function"
 		},
 		{
 			"inputs": [
@@ -217,12 +137,30 @@
 			"inputs": [
 				{
 					"internalType": "address",
-					"name": "account",
+					"name": "from",
 					"type": "address"
 				},
 				{
 					"internalType": "uint256",
 					"name": "amount",
+					"type": "uint256"
+				}
+			],
+			"name": "burn",
+			"outputs": [],
+			"stateMutability": "nonpayable",
+			"type": "function"
+		},
+		{
+			"inputs": [
+				{
+					"internalType": "address",
+					"name": "account",
+					"type": "address"
+				},
+				{
+					"internalType": "uint256",
+					"name": "value",
 					"type": "uint256"
 				}
 			],
@@ -298,25 +236,6 @@
 					"internalType": "address",
 					"name": "account",
 					"type": "address"
-				}
-			],
-			"name": "isMinter",
-			"outputs": [
-				{
-					"internalType": "bool",
-					"name": "",
-					"type": "bool"
-				}
-			],
-			"stateMutability": "view",
-			"type": "function"
-		},
-		{
-			"inputs": [
-				{
-					"internalType": "address",
-					"name": "account",
-					"type": "address"
 				},
 				{
 					"internalType": "uint256",
@@ -346,26 +265,6 @@
 				}
 			],
 			"stateMutability": "view",
-			"type": "function"
-		},
-		{
-			"inputs": [],
-			"name": "owner",
-			"outputs": [
-				{
-					"internalType": "address",
-					"name": "",
-					"type": "address"
-				}
-			],
-			"stateMutability": "view",
-			"type": "function"
-		},
-		{
-			"inputs": [],
-			"name": "renounceMinter",
-			"outputs": [],
-			"stateMutability": "nonpayable",
 			"type": "function"
 		},
 		{
@@ -446,21 +345,8 @@
 			],
 			"stateMutability": "nonpayable",
 			"type": "function"
-		},
-		{
-			"inputs": [
-				{
-					"internalType": "address",
-					"name": "newOwner",
-					"type": "address"
-				}
-			],
-			"name": "transferOwnership",
-			"outputs": [],
-			"stateMutability": "nonpayable",
-			"type": "function"
 		}
-	],
+   ],
   "bytecode": "0x",
   "deployedBytecode": "0x",
   "linkReferences": {},

--- a/precompiles/erc20/approve.go
+++ b/precompiles/erc20/approve.go
@@ -351,7 +351,6 @@ func (p Precompile) approve(ctx sdk.Context, stateDB vm.StateDB, spender, owner 
 func (p *Precompile) spendAllowance(ctx sdk.Context, stateDB vm.StateDB, owner, spender common.Address, amount *big.Int) error {
 	_, _, allowance, err := GetAuthzExpirationAndAllowance(p.AuthzKeeper, ctx, spender, owner, p.tokenPair.Denom)
 	if err != nil {
-		fmt.Println("err", err)
 		allowance = common.Big0
 	}
 

--- a/precompiles/erc20/erc20.go
+++ b/precompiles/erc20/erc20.go
@@ -35,9 +35,8 @@ const (
 	GasTotalSupply       = 2_477
 	GasBalanceOf         = 2_851
 	GasAllowance         = 3_246
-	GasMint              = 3_000_000
-	GasBurn              = 3_000_000
-	GasTransferOwnership = 50_000
+	GasMint              = 50_000
+	GasTransferOwnership = 25_000
 )
 
 // Embed abi json file to the executable binary. Needed when importing as dependency.
@@ -119,7 +118,9 @@ func (p Precompile) RequiredGas(input []byte) uint64 {
 	case MintMethod:
 		return GasMint
 	case BurnMethod:
-		return GasBurn
+		return GasTransfer
+	case BurnFromMethod:
+		return GasTransfer
 	case TransferOwnershipMethod:
 		return GasTransferOwnership
 	// ERC-20 queries
@@ -176,6 +177,7 @@ func (Precompile) IsTransaction(methodName string) bool {
 		auth.DecreaseAllowanceMethod,
 		MintMethod,
 		BurnMethod,
+		BurnFromMethod,
 		TransferOwnershipMethod:
 		return true
 	default:
@@ -206,7 +208,9 @@ func (p *Precompile) HandleMethod(
 	case MintMethod:
 		bz, err = p.Mint(ctx, contract, stateDB, method, args)
 	case BurnMethod:
-		bz, err = p.Burn(ctx, contract, stateDB, method, args)
+		bz, err = p.ExecuteBurn(ctx, contract, stateDB, method, args)
+	case BurnFromMethod:
+		bz, err = p.BurnFrom(ctx, contract, stateDB, method, args)
 	case TransferOwnershipMethod:
 		bz, err = p.TransferOwnership(ctx, contract, stateDB, method, args)
 	// ERC-20 queries

--- a/precompiles/erc20/erc20.go
+++ b/precompiles/erc20/erc20.go
@@ -119,6 +119,8 @@ func (p Precompile) RequiredGas(input []byte) uint64 {
 		return GasMint
 	case BurnMethod:
 		return GasTransfer
+	case Burn0Method:
+		return GasTransfer
 	case BurnFromMethod:
 		return GasTransfer
 	case TransferOwnershipMethod:
@@ -177,6 +179,7 @@ func (Precompile) IsTransaction(methodName string) bool {
 		auth.DecreaseAllowanceMethod,
 		MintMethod,
 		BurnMethod,
+		Burn0Method,
 		BurnFromMethod,
 		TransferOwnershipMethod:
 		return true
@@ -208,7 +211,9 @@ func (p *Precompile) HandleMethod(
 	case MintMethod:
 		bz, err = p.Mint(ctx, contract, stateDB, method, args)
 	case BurnMethod:
-		bz, err = p.ExecuteBurn(ctx, contract, stateDB, method, args)
+		bz, err = p.Burn(ctx, contract, stateDB, method, args)
+	case Burn0Method:
+		bz, err = p.BurnFrom(ctx, contract, stateDB, method, args)
 	case BurnFromMethod:
 		bz, err = p.BurnFrom(ctx, contract, stateDB, method, args)
 	case TransferOwnershipMethod:

--- a/precompiles/erc20/erc20.go
+++ b/precompiles/erc20/erc20.go
@@ -35,8 +35,7 @@ const (
 	GasTotalSupply       = 2_477
 	GasBalanceOf         = 2_851
 	GasAllowance         = 3_246
-	GasMint              = 50_000
-	GasTransferOwnership = 25_000
+	GasTransferOwnership = 50_000
 )
 
 // Embed abi json file to the executable binary. Needed when importing as dependency.
@@ -116,7 +115,7 @@ func (p Precompile) RequiredGas(input []byte) uint64 {
 	case auth.DecreaseAllowanceMethod:
 		return GasDecreaseAllowance
 	case MintMethod:
-		return GasMint
+		return GasTransfer
 	case BurnMethod:
 		return GasTransfer
 	case Burn0Method:

--- a/precompiles/erc20/erc20.go
+++ b/precompiles/erc20/erc20.go
@@ -213,7 +213,7 @@ func (p *Precompile) HandleMethod(
 	case BurnMethod:
 		bz, err = p.Burn(ctx, contract, stateDB, method, args)
 	case Burn0Method:
-		bz, err = p.BurnFrom(ctx, contract, stateDB, method, args)
+		bz, err = p.Burn0(ctx, contract, stateDB, method, args)
 	case BurnFromMethod:
 		bz, err = p.BurnFrom(ctx, contract, stateDB, method, args)
 	case TransferOwnershipMethod:

--- a/precompiles/erc20/erc20_test.go
+++ b/precompiles/erc20/erc20_test.go
@@ -147,7 +147,7 @@ func (s *PrecompileTestSuite) TestRequiredGas() {
 				s.Require().NoError(err, "expected no error packing ABI")
 				return bz
 			},
-			expGas: erc20.GasMint,
+			expGas: erc20.GasTransfer,
 		},
 		{
 			name: erc20.BurnMethod,

--- a/precompiles/erc20/erc20_test.go
+++ b/precompiles/erc20/erc20_test.go
@@ -29,6 +29,7 @@ func (s *PrecompileTestSuite) TestIsTransaction() {
 	s.Require().True(s.precompile.IsTransaction(erc20.MintMethod))
 	s.Require().True(s.precompile.IsTransaction(erc20.BurnMethod))
 	s.Require().True(s.precompile.IsTransaction(erc20.BurnFromMethod))
+	s.Require().True(s.precompile.IsTransaction(erc20.Burn0Method))
 	s.Require().True(s.precompile.IsTransaction(erc20.TransferOwnershipMethod))
 }
 
@@ -152,6 +153,15 @@ func (s *PrecompileTestSuite) TestRequiredGas() {
 			name: erc20.BurnMethod,
 			malleate: func() []byte {
 				bz, err := s.precompile.ABI.Pack(erc20.BurnMethod, big.NewInt(1))
+				s.Require().NoError(err, "expected no error packing ABI")
+				return bz
+			},
+			expGas: erc20.GasTransfer,
+		},
+		{
+			name: erc20.Burn0Method,
+			malleate: func() []byte {
+				bz, err := s.precompile.ABI.Pack(erc20.Burn0Method, s.keyring.GetAddr(0), big.NewInt(1))
 				s.Require().NoError(err, "expected no error packing ABI")
 				return bz
 			},

--- a/precompiles/erc20/erc20_test.go
+++ b/precompiles/erc20/erc20_test.go
@@ -28,6 +28,7 @@ func (s *PrecompileTestSuite) TestIsTransaction() {
 	s.Require().True(s.precompile.IsTransaction(erc20.TransferFromMethod))
 	s.Require().True(s.precompile.IsTransaction(erc20.MintMethod))
 	s.Require().True(s.precompile.IsTransaction(erc20.BurnMethod))
+	s.Require().True(s.precompile.IsTransaction(erc20.BurnFromMethod))
 	s.Require().True(s.precompile.IsTransaction(erc20.TransferOwnershipMethod))
 }
 
@@ -154,7 +155,16 @@ func (s *PrecompileTestSuite) TestRequiredGas() {
 				s.Require().NoError(err, "expected no error packing ABI")
 				return bz
 			},
-			expGas: erc20.GasBurn,
+			expGas: erc20.GasTransfer,
+		},
+		{
+			name: erc20.BurnFromMethod,
+			malleate: func() []byte {
+				bz, err := s.precompile.ABI.Pack(erc20.BurnFromMethod, s.keyring.GetAddr(0), big.NewInt(1))
+				s.Require().NoError(err, "expected no error packing ABI")
+				return bz
+			},
+			expGas: erc20.GasTransfer,
 		},
 		{
 			name: erc20.TransferOwnershipMethod,

--- a/precompiles/erc20/tx.go
+++ b/precompiles/erc20/tx.go
@@ -258,7 +258,7 @@ func (p *Precompile) BurnFrom(
 		return nil, ConvertErrToERC20Error(err)
 	}
 
-	if err := p.burn(ctx, stateDB, burnerAddr, amount, true); err != nil {
+	if err := p.burn(ctx, stateDB, spenderAddr, amount, true); err != nil {
 		return nil, ConvertErrToERC20Error(err)
 	}
 

--- a/precompiles/erc20/tx.go
+++ b/precompiles/erc20/tx.go
@@ -305,9 +305,9 @@ func (p *Precompile) burn(ctx sdk.Context, stateDB vm.StateDB, burnerAddr common
 		return ConvertErrToERC20Error(err)
 	}
 
-	if p.tokenPair.Denom == evmtypes.GetEVMCoinDenom() {
+	if p.tokenPair.Denom == utils.BaseDenom {
 		p.SetBalanceChangeEntries(
-			cmn.NewBalanceChangeEntry(burnerAddr, coins.AmountOf(evmtypes.GetEVMCoinDenom()).BigInt(), cmn.Sub))
+			cmn.NewBalanceChangeEntry(burnerAddr, coins.AmountOf(utils.BaseDenom).BigInt(), cmn.Sub))
 	}
 
 	if err = p.EmitTransferEvent(ctx, stateDB, burnerAddr, ZeroAddress, amount); err != nil {

--- a/precompiles/erc20/tx.go
+++ b/precompiles/erc20/tx.go
@@ -258,8 +258,12 @@ func (p *Precompile) BurnFrom(
 		return nil, ConvertErrToERC20Error(err)
 	}
 
-	if err := p.burn(ctx, stateDB, spenderAddr, amount, true); err != nil {
+	if err := p.burn(ctx, stateDB, spenderAddr, amount, false); err != nil {
 		return nil, ConvertErrToERC20Error(err)
+	}
+
+	if err = p.EmitTransferEvent(ctx, stateDB, burnerAddr, ZeroAddress, amount); err != nil {
+		return nil, err
 	}
 
 	var newAllowance *big.Int

--- a/precompiles/erc20/tx_test.go
+++ b/precompiles/erc20/tx_test.go
@@ -446,7 +446,6 @@ func (s *PrecompileTestSuite) TestBurn() {
 		},
 	}
 
-	//nolint:dupl
 	for _, tc := range testcases {
 		s.Run(tc.name, func() {
 			s.SetupTest()
@@ -557,7 +556,6 @@ func (s *PrecompileTestSuite) TestBurn0() {
 		},
 	}
 
-	//nolint:dupl
 	for _, tc := range testcases {
 		s.Run(tc.name, func() {
 			s.SetupTest()

--- a/precompiles/erc20/types.go
+++ b/precompiles/erc20/types.go
@@ -187,6 +187,7 @@ func ParseMintArgs(args []interface{}) (to common.Address, amount *big.Int, err 
 	return to, amount, nil
 }
 
+// ParseBurnArgs parses the arguments from the burn method and returns the amount.
 func ParseBurnArgs(args []interface{}) (amount *big.Int, err error) {
 	if len(args) != 1 {
 		return nil, fmt.Errorf("invalid number of arguments; expected 1; got: %d", len(args))
@@ -198,6 +199,26 @@ func ParseBurnArgs(args []interface{}) (amount *big.Int, err error) {
 	}
 
 	return amount, nil
+}
+
+// ParseBurnFromArgs parses the arguments from the burnFrom method and returns the
+// from address and amount.
+func ParseBurnFromArgs(args []interface{}) (from common.Address, amount *big.Int, err error) {
+	if len(args) != 2 {
+		return common.Address{}, nil, fmt.Errorf("invalid number of arguments; expected 2; got: %d", len(args))
+	}
+
+	from, ok := args[0].(common.Address)
+	if !ok {
+		return common.Address{}, nil, fmt.Errorf("invalid from address: %v", args[0])
+	}
+
+	amount, ok = args[1].(*big.Int)
+	if !ok {
+		return common.Address{}, nil, fmt.Errorf("invalid amount: %v", args[1])
+	}
+
+	return from, amount, nil
 }
 
 // ParseTransferOwnershipArgs parses the arguments from the transferOwnership method and returns the new owner address.

--- a/precompiles/erc20/types.go
+++ b/precompiles/erc20/types.go
@@ -201,6 +201,24 @@ func ParseBurnArgs(args []interface{}) (amount *big.Int, err error) {
 	return amount, nil
 }
 
+func ParseBurn0Args(args []interface{}) (spender common.Address, amount *big.Int, err error) {
+	if len(args) != 2 {
+		return common.Address{}, nil, fmt.Errorf("invalid number of arguments; expected 2; got: %d", len(args))
+	}
+
+	spender, ok := args[0].(common.Address)
+	if !ok {
+		return common.Address{}, nil, fmt.Errorf("invalid spender address: %v", args[0])
+	}
+
+	amount, ok = args[1].(*big.Int)
+	if !ok {
+		return common.Address{}, nil, fmt.Errorf("invalid amount: %v", args[1])
+	}
+
+	return spender, amount, nil
+}
+
 // ParseBurnFromArgs parses the arguments from the burnFrom method and returns the
 // from address and amount.
 func ParseBurnFromArgs(args []interface{}) (from common.Address, amount *big.Int, err error) {

--- a/precompiles/erc20/types_test.go
+++ b/precompiles/erc20/types_test.go
@@ -403,6 +403,66 @@ func (s *PrecompileTestSuite) TestParseBurnArgs() {
 	}
 }
 
+func (s *PrecompileTestSuite) TestParseBurnFromArgs() {
+	from := utiltx.GenerateAddress()
+	amount := big.NewInt(100)
+
+	testcases := []struct {
+		name        string
+		args        []interface{}
+		expPass     bool
+		errContains string
+	}{
+		{
+			name: "fail - invalid from address",
+			args: []interface{}{
+				"invalid address",
+				amount,
+			},
+			errContains: "invalid from address",
+		},
+		{
+			name: "fail - invalid amount",
+			args: []interface{}{
+				from,
+				"invalid amount",
+			},
+			errContains: "invalid amount",
+		},
+		{
+			name: "fail - invalid number of arguments",
+			args: []interface{}{
+				s.keyring.GetAddr(0),
+				big.NewInt(1),
+				big.NewInt(2),
+			},
+			errContains: "invalid number of arguments",
+		},
+		{
+			name: "pass - correct arguments",
+			args: []interface{}{
+				from,
+				amount,
+			},
+			expPass: true,
+		},
+	}
+
+	for _, tc := range testcases {
+		s.Run(tc.name, func() {
+			from, amount, err := erc20.ParseBurnFromArgs(tc.args)
+			if tc.expPass {
+				s.Require().NoError(err, "unexpected error parsing the burnFrom arguments")
+				s.Require().Equal(from, tc.args[0], "expected different from address")
+				s.Require().Equal(amount, tc.args[1], "expected different amount")
+			} else {
+				s.Require().Error(err, "expected an error parsing the burnFrom arguments")
+				s.Require().ErrorContains(err, tc.errContains, "expected different error message")
+			}
+		})
+	}
+}
+
 func (s *PrecompileTestSuite) TestParseOwnerArgs() {
 	testcases := []struct {
 		name        string

--- a/precompiles/erc20/types_test.go
+++ b/precompiles/erc20/types_test.go
@@ -403,6 +403,66 @@ func (s *PrecompileTestSuite) TestParseBurnArgs() {
 	}
 }
 
+func (s *PrecompileTestSuite) TestParseBurn0Args() {
+	spender := utiltx.GenerateAddress()
+	amount := big.NewInt(100)
+
+	testcases := []struct {
+		name        string
+		args        []interface{}
+		expPass     bool
+		errContains string
+	}{
+		{
+			name: "pass - correct arguments",
+			args: []interface{}{
+				spender,
+				amount,
+			},
+			expPass: true,
+		},
+		{
+			name: "fail - invalid spender address",
+			args: []interface{}{
+				"invalid address",
+				amount,
+			},
+			errContains: "invalid spender address",
+		},
+		{
+			name: "fail - invalid amount",
+			args: []interface{}{
+				spender,
+				"invalid amount",
+			},
+			errContains: "invalid amount",
+		},
+		{
+			name: "fail - invalid number of arguments",
+			args: []interface{}{
+				spender,
+				amount,
+				big.NewInt(1),
+			},
+			errContains: "invalid number of arguments",
+		},
+	}
+
+	for _, tc := range testcases {
+		s.Run(tc.name, func() {
+			spender, amount, err := erc20.ParseBurn0Args(tc.args)
+			if tc.expPass {
+				s.Require().NoError(err, "unexpected error parsing the burn0 arguments")
+				s.Require().Equal(spender, tc.args[0], "expected different spender")
+				s.Require().Equal(amount, tc.args[1], "expected different amount")
+			} else {
+				s.Require().Error(err, "expected an error parsing the burn0 arguments")
+				s.Require().ErrorContains(err, tc.errContains, "expected different error message")
+			}
+		})
+	}
+}
+
 func (s *PrecompileTestSuite) TestParseBurnFromArgs() {
 	from := utiltx.GenerateAddress()
 	amount := big.NewInt(100)


### PR DESCRIPTION
# Description

This PR aims to add the following methods:

`burn(address from, uint256 amount)`
`burnFrom(address from, uint256 amount)`

to the ERC20 precompiles. 

---

## Author Checklist

**All** items are required. Please add a note to the item if the item is not applicable and
please add links to any relevant follow up issues.

I have...

- [x] tackled an existing issue or discussed with a team member
- [x] left instructions on how to review the changes
- [x] targeted the correct branch (see [PR Targeting](https://github.com/evmos/evmos/blob/main/CONTRIBUTING.md#pr-targeting))

## Reviewers Checklist

**All** items are required.
Please add a note if the item is not applicable
and please add your handle next to the items reviewed
if you only reviewed selected items.

I have...

- [x] added a relevant changelog entry to the `Unreleased` section in `CHANGELOG.md`
- [x] confirmed all author checklist items have been addressed
- [x] confirmed that this PR does not change production code
- [x] reviewed content
- [x] tested instructions (if applicable)
- [x] confirmed all CI checks have passed