### PR TITLE
feat(opcodes/eip5656/mcopy): add mCopy opcode, EIP-5656

### DIFF
--- a/x/evm/core/vm/instructions.go
+++ b/x/evm/core/vm/instructions.go
@@ -522,6 +522,38 @@ func opMstore8(pc *uint64, interpreter *EVMInterpreter, scope *ScopeContext) ([]
 	return nil, nil
 }
 
+// opMcopy implements EIP-5656 MCOPY operation
+//
+// Stack Input:
+//   [ length     | top    ]  -- number of bytes to copy
+//   [ srcOffset  | second ]  -- source memory offset
+//   [ destOffset | third  ]  -- destination memory offset
+//
+// Operation Flow:
+//  1. Pop parameters from stack:
+//     - destination offset
+//     - source offset 
+//     - length
+//  2. Convert stack items to uint64
+//  3. Copy memory from source to destination
+func opMcopy(pc *uint64, interpreter *EVMInterpreter, scope *ScopeContext) ([]byte, error) {
+	var (
+		destOffset = scope.Stack.Pop()
+		srcOffset  = scope.Stack.Pop()
+		length     = scope.Stack.Pop()
+	)
+
+	// Convert stack items to integers
+	destOffsetInt := destOffset.Uint64()
+	srcOffsetInt := srcOffset.Uint64()
+	lengthInt := length.Uint64()
+
+	// Copy memory
+	scope.Memory.Set(destOffsetInt, lengthInt, scope.Memory.GetPtr(int64(srcOffsetInt), int64(lengthInt)))
+
+	return nil, nil
+}
+
 func opSload(pc *uint64, interpreter *EVMInterpreter, scope *ScopeContext) ([]byte, error) {
 	loc := scope.Stack.Peek()
 	hash := common.Hash(loc.Bytes32())

--- a/x/evm/core/vm/instructions_test.go
+++ b/x/evm/core/vm/instructions_test.go
@@ -564,6 +564,31 @@ func TestOpMstore(t *testing.T) {
 	}
 }
 
+func TestOpMcopy(t *testing.T) {
+	var (
+		env            = NewEVM(BlockContext{}, TxContext{}, nil, params.TestChainConfig, Config{})
+		stack, err     = NewStack()
+		mem            = NewMemory()
+		evmInterpreter = NewEVMInterpreter(env, env.Config)
+		pc            = uint64(0)
+	)
+	require.NoError(t, err)
+
+	env.interpreter = evmInterpreter
+	mem.Resize(100)
+	mem.Set(10, 3, []byte{0x01, 0x02, 0x03})
+
+	stack.Push(new(uint256.Int).SetUint64(3))  // length
+	stack.Push(new(uint256.Int).SetUint64(10)) // srcOffset 
+	stack.Push(new(uint256.Int).SetUint64(20)) // destOffset
+
+	opMcopy(&pc, evmInterpreter, &ScopeContext{mem, stack, nil})
+
+	expected := []byte{0x01, 0x02, 0x03}
+	actual := mem.GetCopy(20, 3)
+	require.Equal(t, expected, actual)
+}
+
 func BenchmarkOpMstore(bench *testing.B) {
 	var (
 		env            = NewEVM(BlockContext{}, TxContext{}, nil, params.TestChainConfig, Config{})

--- a/x/evm/core/vm/jump_table.go
+++ b/x/evm/core/vm/jump_table.go
@@ -576,6 +576,14 @@ func newFrontierInstructionSet() JumpTable {
 			minStack:    minStack(2, 0),
 			maxStack:    maxStack(2, 0),
 		},
+		MCOPY: {
+			execute:     opMcopy,
+			constantGas: GasFastestStep,
+			dynamicGas:  gasMStore,
+			minStack:    minStack(3, 0),
+			maxStack:    maxStack(3, 0),
+			memorySize:  memoryMStore,
+		},
 		SLOAD: {
 			execute:     opSload,
 			constantGas: params.SloadGasFrontier,

--- a/x/evm/core/vm/opcodes.go
+++ b/x/evm/core/vm/opcodes.go
@@ -119,6 +119,7 @@ const (
 	MSIZE    OpCode = 0x59
 	GAS      OpCode = 0x5a
 	JUMPDEST OpCode = 0x5b
+	MCOPY    OpCode = 0x5e
 	PUSH0    OpCode = 0x5f
 )
 
@@ -301,6 +302,7 @@ var opCodeToString = map[OpCode]string{
 	MSIZE:    "MSIZE",
 	GAS:      "GAS",
 	JUMPDEST: "JUMPDEST",
+	MCOPY:    "MCOPY",
 	PUSH0:    "PUSH0",
 
 	// 0x60 range - push.
@@ -465,6 +467,7 @@ var stringToOp = map[string]OpCode{
 	"MSIZE":          MSIZE,
 	"GAS":            GAS,
 	"JUMPDEST":       JUMPDEST,
+	"MCOPY":          MCOPY,
 	"PUSH0":          PUSH0,
 	"PUSH1":          PUSH1,
 	"PUSH2":          PUSH2,


### PR DESCRIPTION
### Description
This PR aims to add the `MCOPY (0x5e)` opcode to the EVM implementation in Evmos. The `MCOPY` opcode, introduced in Solidity 0.8.25, enables efficient memory copying within the EVM. This change ensures compatibility with contracts compiled using Solidity versions ^0.8.25 and resolves the issue where calls to functions utilizing `MCOPY` fail with an "opcode not defined" error.

The following changes have been implemented:
- Added the `MCOPY (0x5e)` opcode to the EVM interpreter's opcode table.
- Implemented the logic for the `MCOPY` operation, including memory copying.
- Added a unit test to verify the `MCOPY` implementation.

Author Checklist
All items are required. Please add a note to the item if it is not applicable, and please add links to any relevant follow-up issues.
- [x] I have tackled an existing issue ([#53](https://github.com/xrplevm/node/issues/53)).
- [x] I have left instructions on how to review the changes:
  - Review the implementation of the `MCOPY` opcode in `x/evm/core/vm/instructions.go`.
  - Verify the unit test in `x/evm/core/vm/instructions_test.go`.
  - Test the changes by following the deployment process described in the issue [#53](https://github.com/xrplevm/node/issues/53) that uses `MCOPY` from the provided `MCopyTest` contract to the local node by launching: [local-node.sh](https://github.com/xrplevm/node/blob/main/local-node.sh)
- [x] I have targeted the correct branch by deducting the team's practices with this forked repo, rebasing latest work off `v20.0.0-exrp`

Reviewers Checklist
All items are required. Please add a note if the item is not applicable and please add your handle next to the items reviewed if you only reviewed selected items.
- [ ] I have added a relevant changelog entry to the Unreleased section in CHANGELOG.md.
- [ ] I have confirmed all author checklist items have been addressed.
- [ ] I have confirmed that this PR does not change production code outside the EVM module.
- [ ] I have reviewed the content.
- [ ] I have tested the instructions (deployed a contract using `MCOPY` and verified functionality).
- [ ] I have confirmed all CI checks have passed.